### PR TITLE
Fix  pip install on non windows machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To test and have a base to start using our API with Python scripts, you can use 
 ### Unauthorized HTTP error 401
 - _**Message:**_
   ```
-  requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://secure.petro-logistics.com/api/v2/aggregatemovementsdata.php
+  requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://secure.petro-logistics.com/api/v2/aggregatemovementsdata.php
   ```
 - _**Additional infos:**_ It is possible that some security settings prevent access to our services.
 - _**Solution:**_ Update firewall settings to trust our domain: `petro-logistics.com`.
@@ -27,19 +27,19 @@ To test and have a base to start using our API with Python scripts, you can use 
 ### SSLError: certificate verify failed
 - _**Message:**_
   ```
-  SSLError: HTTPSConnectionPool(host=‘secure.petro-logistics.com’, port=443): Max retries exceeded with url: /api/v2/aggregatemovementsdata.php (Caused by SSLError(SSLError(“bad handshake: Error([(‘SSL routines’, ‘tls_process_server_certificate’, ‘certificate verify failed’)])“)))
+  SSLError: HTTPSConnectionPool(host='secure.petro-logistics.com', port=443): Max retries exceeded with url: /api/v2/aggregatemovementsdata.php (Caused by SSLError(SSLError("bad handshake: Error([('SSL routines', 'tls_process_server_certificate', 'certificate verify failed')])")))
   ```
 - _**Additional infos:**_ The problem seems to be the same as above, it is possible that some security settings prevent access to our services. Possible reasons:
   - You are using a self signed certificate for the resource you are accessing.
   - Your company intercepts and inspects HTTPS traffic; hence adding its own certificates at the top of the certificate chain.
-- _**Solution:**_ Contact company’s IT team with above error and possible reasons.
+- _**Solution:**_ Contact company's IT team with above error and possible reasons.
 
 ### Certificate revocation error
 - _**Message:**_
   ```
-  fatal: unable to access ’https://github.com/Petro-Logistics/petro-api-python/’: schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
+  fatal: unable to access 'https://github.com/Petro-Logistics/petro-api-python/': schannel: next InitializeSecurityContext failed: Unknown error (0x80092012) - The revocation function was unable to check revocation for the certificate.
   ```
 - _**Additional infos:**_ The problem seems to be in the Windows git configuration, or in the settings of the firewall. Possible solutions:
   - https://github.com/desktop/desktop/issues/2187#issuecomment-313309981
   - https://stackoverflow.com/questions/45556189/git-the-revocation-function-was-unable-to-check-revocation-for-the-certificate
-- _**Solution:**_ Contact company’s IT team with above error and possible reasons.
+- _**Solution:**_ Contact company's IT team with above error and possible reasons.


### PR DESCRIPTION
Previously, the README contained characters encoded with Windows-1252 (0.73). On non windows machines, this breaks pip install with a UnicodeDecodeError:

```
pip install git+https://github.com/Petro-Logistics/petro-api-python
Collecting git+https://github.com/Petro-Logistics/petro-api-python (from -r requirements.txt (line 43))
  Cloning https://github.com/Petro-Logistics/petro-api-python to /private/var/folders/2m/jp5gz74170l1vk3231j78nqh0000gn/T/pip-req-build-yhbjlcrd
  Running command git clone --filter=blob:none --quiet https://github.com/Petro-Logistics/petro-api-python /private/var/folders/2m/jp5gz74170l1vk3231j78nqh0000gn/T/pip-req-build-yhbjlcrd
  Resolved https://github.com/Petro-Logistics/petro-api-python to commit 94da517144a499f797de4820ec6eef393cedc201
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 36, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/2m/jp5gz74170l1vk3231j78nqh0000gn/T/pip-req-build-yhbjlcrd/setup.py", line 12, in <module>
          README = readme.read()
        File "/Users/Neil/.pyenv/versions/3.7.11/lib/python3.7/codecs.py", line 322, in decode
          (result, consumed) = self._buffer_decode(data, self.errors, final)
      UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa0 in position 986: invalid start byte
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

The non utf-8 characters are for smart quotes. This change replaces the smart quotes with regular straight quotes